### PR TITLE
refactor: use context for automatic lsp process cleanup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,6 @@ var rootCmd = &cobra.Command{
 		ctx := context.Background()
 
 		app := app.New(ctx, conn)
-		defer app.Close()
 		logging.Info("Starting termai...")
 		zone.NewGlobal()
 		tui := tea.NewProgram(

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -48,8 +48,8 @@ type Client struct {
 	openFilesMu sync.RWMutex
 }
 
-func NewClient(command string, args ...string) (*Client, error) {
-	cmd := exec.Command(command, args...)
+func NewClient(ctx context.Context, command string, args ...string) (*Client, error) {
+	cmd := exec.CommandContext(ctx, command, args...)
 	// Copy env
 	cmd.Env = os.Environ()
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

We keep a cleanup map to clean up all LSP processes when they exit.

## What is the new behavior?

We pass the existing ctx to the lsp process cmd to automatically clean up the process on ctx->Done()