### PR TITLE
fix(tool/grep): always show file names with rg

### DIFF
--- a/internal/llm/tools/grep.go
+++ b/internal/llm/tools/grep.go
@@ -211,7 +211,7 @@ func searchWithRipgrep(pattern, path, include string) ([]grepMatch, error) {
 	}
 
 	// Use -n to show line numbers and include the matched line
-	args := []string{"-n", pattern}
+	args := []string{"-H", "-n", pattern}
 	if include != "" {
 		args = append(args, "--glob", include)
 	}


### PR DESCRIPTION
Add `-H` flag to ripgrep so it always prints file names.

Ripgrep does not print file names when searching a single file, which breaks the grep tool parsing.
![opencode-rg-failure](https://github.com/user-attachments/assets/70c53213-0f36-4672-aaee-b4c389f0aafb)

After adding `-H`:
![opencode-rg-success](https://github.com/user-attachments/assets/ef524eb3-d4c7-46b4-8520-1920b609fc96)

