### PR TITLE
fix(mcp): ensure required field is initialized if nil

### DIFF
--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -33,11 +33,15 @@ type MCPClient interface {
 }
 
 func (b *mcpTool) Info() tools.ToolInfo {
+	required := b.tool.InputSchema.Required
+	if required == nil {
+		required = make([]string, 0)
+	}
 	return tools.ToolInfo{
 		Name:        fmt.Sprintf("%s_%s", b.mcpName, b.tool.Name),
 		Description: b.tool.Description,
 		Parameters:  b.tool.InputSchema.Properties,
-		Required:    b.tool.InputSchema.Required,
+		Required:    required,
 	}
 }
 


### PR DESCRIPTION
Some MCP servers don't specify required parameters and set their `required` field as `nil`, which serializes as `null` in JSON. This causes both OpenAI and Copilot OpenAI APIs to reject the schema with a 400 status code:

```
{
    "error": {
        "message": "Invalid schema for function 'string': None is not of type 'array'.",
        "type": "invalid_request_error",
        "param": "tools[number].function.parameters",
        "code": "invalid_function_parameters"
    }
}
```