### PR TITLE
fix(mcp): handle empty input by initializing with empty JSON object

### DIFF
--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -62,6 +62,9 @@ func runTool(ctx context.Context, c MCPClient, toolName string, input string) (t
 	toolRequest := mcp.CallToolRequest{}
 	toolRequest.Params.Name = toolName
 	var args map[string]any
+	if input == "" {
+		input = "{}"
+	}
 	if err = json.Unmarshal([]byte(input), &args); err != nil {
 		return tools.NewTextErrorResponse(fmt.Sprintf("error parsing parameters: %s", err)), nil
 	}

--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/opencode-ai/opencode/internal/config"
 	"github.com/opencode-ai/opencode/internal/llm/tools"
@@ -62,7 +63,7 @@ func runTool(ctx context.Context, c MCPClient, toolName string, input string) (t
 	toolRequest := mcp.CallToolRequest{}
 	toolRequest.Params.Name = toolName
 	var args map[string]any
-	if input == "" {
+	if strings.TrimSpace(input) == "" {
 		input = "{}"
 	}
 	if err = json.Unmarshal([]byte(input), &args); err != nil {

--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -33,11 +33,15 @@ type MCPClient interface {
 }
 
 func (b *mcpTool) Info() tools.ToolInfo {
+	required := b.tool.InputSchema.Required
+	if required == nil {
+		required = make([]string, 0)
+	}
 	return tools.ToolInfo{
 		Name:        fmt.Sprintf("%s_%s", b.mcpName, b.tool.Name),
 		Description: b.tool.Description,
 		Parameters:  b.tool.InputSchema.Properties,
-		Required:    b.tool.InputSchema.Required,
+		Required:    required,
 	}
 }
 


### PR DESCRIPTION
When an MCP server runs with a tool that has an empty string as its `input`, the runner fails with a parameter parsing error. This issue was found with Copilot's Claude models, which pass `""` instead of `"{}"` sometimes.

![image](https://github.com/user-attachments/assets/4acbf687-7673-4198-a0d2-db424a6df597)
