### PR TITLE
Fix GitHub Copilot authentication flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can configure OpenCode using environment variables:
 | `ANTHROPIC_API_KEY`        | For Claude models                                                                |
 | `OPENAI_API_KEY`           | For OpenAI models                                                                |
 | `GEMINI_API_KEY`           | For Google Gemini models                                                         |
-| `GITHUB_TOKEN`             | For Github Copilot models (see [Using Github Copilot](#using-github-copilot))    |
+| `GITHUB_TOKEN`             | For Github Copilot models (see [Using GitHub Copilot](#using-github-copilot))    |
 | `VERTEXAI_PROJECT`         | For Google Cloud VertexAI (Gemini)                                               |
 | `VERTEXAI_LOCATION`        | For Google Cloud VertexAI (Gemini)                                               |
 | `GROQ_API_KEY`             | For Groq models                                                                  |
@@ -236,6 +236,37 @@ OpenCode supports a variety of AI models from different providers:
 - O4 Mini
 - Gemini 2.0 Flash
 - Gemini 2.5 Pro
+
+#### Using GitHub Copilot
+
+OpenCode supports using GitHub Copilot's models through a streamlined authentication flow:
+
+1. Add Copilot to your configuration:
+```json
+{
+  "agents": {
+    "coder": {
+      "model": "copilot.claude-3.7-sonnet",
+      "maxTokens": 16384
+    }
+  },
+  "providers": {
+    "copilot": {
+      "disabled": false
+    }
+  }
+}
+```
+
+2. When you first run OpenCode with a Copilot model selected, the application will:
+   - Check for an existing Copilot token in standard locations (hosts.json, apps.json)
+   - If no token is found, automatically start the authentication flow
+   - Prompt you to visit a GitHub URL and enter a device code
+   - Store the token in the standard GitHub Copilot location (`~/.config/github-copilot/hosts.json`)
+
+3. For subsequent runs, OpenCode will use your saved token automatically.
+
+Note: You need an active GitHub Copilot subscription to use these models.
 
 ### Google
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can configure OpenCode using environment variables:
 | `ANTHROPIC_API_KEY`        | For Claude models                                                                |
 | `OPENAI_API_KEY`           | For OpenAI models                                                                |
 | `GEMINI_API_KEY`           | For Google Gemini models                                                         |
-| `GITHUB_TOKEN`             | For Github Copilot models (see [Using GitHub Copilot](#using-github-copilot))    |
+| `GITHUB_COPILOT_TOKEN`     | For Github Copilot models (see [Using GitHub Copilot](#using-github-copilot))    |
 | `VERTEXAI_PROJECT`         | For Google Cloud VertexAI (Gemini)                                               |
 | `VERTEXAI_LOCATION`        | For Google Cloud VertexAI (Gemini)                                               |
 | `GROQ_API_KEY`             | For Groq models                                                                  |
@@ -648,7 +648,7 @@ the tool with your github account. This should create a github token at one of t
 - ~/.config/github-copilot/[hosts,apps].json
 - $XDG_CONFIG_HOME/github-copilot/[hosts,apps].json
 
-If using an explicit github token, you may either set the $GITHUB_TOKEN environment variable or add it to the opencode.json config file at `providers.copilot.apiKey`.
+If using an explicit github token, you may either set the $GITHUB_COPILOT_TOKEN environment variable or add it to the opencode.json config file at `providers.copilot.apiKey`.
 
 ## Using a self-hosted model provider
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -640,8 +640,6 @@ func Validate() error {
 		return fmt.Errorf("config not loaded")
 	}
 
-	logging.Debug("Starting configuration validation")
-
 	// Validate agent models
 	for name, agent := range cfg.Agents {
 		logging.Debug("Validating agent", "name", name, "model", agent.Model)

--- a/internal/llm/provider/copilot.go
+++ b/internal/llm/provider/copilot.go
@@ -57,30 +57,6 @@ func (c *copilotClient) isAnthropicModel() bool {
 	return false
 }
 
-func (c *copilotClient) getGitHubTokenScopes(githubToken string) (string, error) {
-	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create GitHub API request: %w", err)
-	}
-
-	req.Header.Set("Authorization", "Token "+githubToken)
-	req.Header.Set("User-Agent", "OpenCode/1.0")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to query GitHub API: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("GitHub API request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	scopes := resp.Header.Get("X-OAuth-Scopes")
-	return scopes, nil
-}
-
 // GitHub OAuth device flow response
 type GitHubDeviceCodeResponse struct {
 	DeviceCode      string `json:"device_code"`
@@ -92,189 +68,25 @@ type GitHubDeviceCodeResponse struct {
 
 // GitHub OAuth token response
 type GitHubTokenResponse struct {
+	// Standard OAuth fields 
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
 	Scope       string `json:"scope"`
+	
+	// For backward compatibility with any custom formats
+	Token string `json:"token,omitempty"`
 }
 
-// exchangeGitHubToken exchanges a GitHub token for a Copilot bearer token
-// If the token is provided, it will try to use it directly
-// Otherwise, it will start the GitHub device code flow
-func (c *copilotClient) exchangeGitHubToken(githubToken string) (string, error) {
-	// If a token is provided, try to use it directly
-	if githubToken != "" {
-		prefixLen := 10
-		if len(githubToken) < prefixLen {
-			prefixLen = len(githubToken)
-		}
-		logging.Debug("Exchanging GitHub token", "token_length", len(githubToken), "token_prefix", githubToken[:prefixLen])
-
-		// Check GitHub token scopes first to verify it's a valid token
-		scopes, err := c.getGitHubTokenScopes(githubToken)
-		if err != nil {
-			logging.Error("Failed to get GitHub token scopes", "error", err)
-			// If we can't verify token scopes, just continue - the token exchange will fail if invalid
-		} else {
-			logging.Debug("GitHub token scopes", "scopes", scopes)
-			if !strings.Contains(scopes, "copilot") {
-				logging.Warn("GitHub token does not have copilot scope - token exchange may fail")
-			}
-		}
-
-		// Attempt to exchange for a Copilot bearer token - match VS Code exactly
-		req, err := http.NewRequest("GET", "https://api.github.com/copilot_internal/v2/token", nil)
-		if err != nil {
-			return "", fmt.Errorf("failed to create token exchange request: %w", err)
-		}
-
-		req.Header.Set("Authorization", "token "+githubToken) // Note: "token" not "Token"
-		req.Header.Set("User-Agent", "GithubCopilot/1.133.0")
-		req.Header.Set("Accept", "application/json")
-
-		logging.Debug("Sending token exchange request to GitHub API")
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			logging.Error("Failed HTTP request for token exchange", "error", err)
-			// If we're not in non-interactive mode, try device flow
-			if !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
-				logging.Info("Token exchange HTTP request failed, falling back to device code flow")
-				return c.performDeviceCodeFlow()
-			}
-			return "", fmt.Errorf("failed to exchange GitHub token: %w", err)
-		}
-		defer resp.Body.Close()
-
-		logging.Debug("Token exchange response received", "status", resp.StatusCode, "headers", resp.Header)
-		
-		// Check for HTTP errors
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			logging.Error("Token exchange failed", "status_code", resp.StatusCode, "body", string(body))
-			
-			// If we're not in non-interactive mode, try device flow
-			if !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
-				logging.Info("Token exchange failed, falling back to device code flow")
-				return c.performDeviceCodeFlow()
-			}
-			return "", fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
-		}
-
-		// Success! Read the response
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			logging.Error("Failed to read token response body", "error", err)
-			return "", fmt.Errorf("failed to read token response: %w", err)
-		}
-
-		logging.Debug("Token exchange response body received, length", "bytes", len(body))
-		
-		var tokenResp CopilotTokenResponse
-		if err := json.Unmarshal(body, &tokenResp); err != nil {
-			logging.Error("Failed to decode token response", "error", err)
-			return "", fmt.Errorf("failed to decode token response: %w", err)
-		}
-
-		if tokenResp.Token == "" {
-			logging.Error("Received empty token from GitHub API")
-			
-			// If we're not in non-interactive mode, try device flow
-			if !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
-				logging.Info("Received empty token, falling back to device code flow")
-				return c.performDeviceCodeFlow()
-			}
-			return "", fmt.Errorf("received empty token from GitHub API")
-		}
-
-		prefixLen = 10
-		if len(tokenResp.Token) < prefixLen {
-			prefixLen = len(tokenResp.Token)
-		}
-		logging.Debug("Successfully obtained Copilot bearer token", 
-			"token_prefix", tokenResp.Token[:prefixLen], 
-			"expires_at", tokenResp.ExpiresAt)
-			
-		// Try saving the token for future use
-		saveGitHubToken(githubToken)
-			
-		return tokenResp.Token, nil
-	} else {
-		// No token provided, use device code flow if we're not in non-interactive mode
-		if !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
-			logging.Info("No GitHub token provided, starting device code flow")
-			return c.performDeviceCodeFlow()
-		}
-		return "", fmt.Errorf("no GitHub token available and running in non-interactive mode")
-	}
-}
-
-// saveGitHubToken saves the GitHub token to the standard location for future use
-func saveGitHubToken(token string) {
-	// Only save if we have a token
-	if token == "" {
-		return
-	}
-	
-	// Get the config directory
-	var configDir string
-	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
-		configDir = xdgConfig
-	} else if runtime.GOOS == "windows" {
-		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
-			configDir = localAppData
-		} else {
-			configDir = filepath.Join(os.Getenv("HOME"), "AppData", "Local")
-		}
-	} else {
-		configDir = filepath.Join(os.Getenv("HOME"), ".config")
-	}
-	
-	// Create the directory if it doesn't exist
-	copilotDir := filepath.Join(configDir, "github-copilot")
-	if err := os.MkdirAll(copilotDir, 0755); err != nil {
-		logging.Error("Failed to create github-copilot directory", "error", err)
-		return
-	}
-	
-	// Create the hosts.json file
-	hostsFile := filepath.Join(copilotDir, "hosts.json")
-	
-	// Create the JSON structure
-	hostsData := map[string]map[string]interface{}{
-		"github.com": {
-			"oauth_token": token,
-		},
-	}
-	
-	// Marshal to JSON
-	jsonData, err := json.MarshalIndent(hostsData, "", "  ")
-	if err != nil {
-		logging.Error("Failed to marshal hosts.json", "error", err)
-		return
-	}
-	
-	// Write the file
-	if err := os.WriteFile(hostsFile, jsonData, 0600); err != nil {
-		logging.Error("Failed to write hosts.json", "error", err)
-		return
-	}
-	
-	logging.Info("Saved GitHub token to hosts.json for future use", "path", hostsFile)
-}
-
-// performDeviceCodeFlow initiates the GitHub device code flow and returns a Copilot bearer token
+// performDeviceCodeFlow initiates the GitHub device code flow and returns a GitHub token
 func (c *copilotClient) performDeviceCodeFlow() (string, error) {
 	// Step 1: Get a device code
 	data := url.Values{}
 	
 	// Use the official GitHub Copilot client ID
-	// This is used by multiple Copilot integrations including Neovim
-	// The client ID is publicly visible in VS Code and Neovim plugins
 	const copilotClientID = "Iv1.b507a08c87ecfe98"
 	data.Set("client_id", copilotClientID)
 	data.Set("scope", "user:email read:user copilot")
 	
-	fmt.Printf("Requesting GitHub authentication...\n")
-
 	// Using the exact URL and headers from VS Code Copilot extension
 	req, err := http.NewRequest("POST", "https://github.com/login/device/code", strings.NewReader(data.Encode()))
 	if err != nil {
@@ -296,13 +108,8 @@ func (c *copilotClient) performDeviceCodeFlow() (string, error) {
 		return "", fmt.Errorf("device code request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read device code response: %w", err)
-	}
-
 	var deviceResp GitHubDeviceCodeResponse
-	if err := json.Unmarshal(body, &deviceResp); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
 		return "", fmt.Errorf("failed to parse device code response: %w", err)
 	}
 
@@ -315,7 +122,7 @@ func (c *copilotClient) performDeviceCodeFlow() (string, error) {
 
 	// Step 3: Poll for the token
 	tokenData := url.Values{}
-	tokenData.Set("client_id", copilotClientID) // Use the same client ID as before
+	tokenData.Set("client_id", copilotClientID)
 	tokenData.Set("device_code", deviceResp.DeviceCode)
 	tokenData.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
 
@@ -335,18 +142,21 @@ func (c *copilotClient) performDeviceCodeFlow() (string, error) {
 	defer ticker.Stop()
 
 	fmt.Printf("Waiting for authorization...\n")
-	pollAttempts := 0
+	maxPolls := 60 // Maximum polling attempts
+	pollCount := 0
 	
 	for {
 		select {
 		case <-ticker.C:
-			pollAttempts++
+			pollCount++
+			if pollCount > maxPolls {
+				return "", fmt.Errorf("maximum polling attempts reached, please try again")
+			}
 			
 			// Make a request to check if the user has authorized
 			tokenReq, err := http.NewRequest("POST", "https://github.com/login/oauth/access_token", 
 				strings.NewReader(tokenData.Encode()))
 			if err != nil {
-				logging.Error("Failed to create token request", "error", err)
 				return "", fmt.Errorf("failed to create token request: %w", err)
 			}
 
@@ -356,158 +166,121 @@ func (c *copilotClient) performDeviceCodeFlow() (string, error) {
 
 			tokenResp, err := c.httpClient.Do(tokenReq)
 			if err != nil {
-				logging.Error("Failed to make token request", "error", err)
 				return "", fmt.Errorf("failed token request: %w", err)
 			}
+			defer tokenResp.Body.Close()
 
-			logging.Debug("Token poll response status", "status", tokenResp.StatusCode)
-			
-			tokenRespBody, err := io.ReadAll(tokenResp.Body)
-			tokenResp.Body.Close()
+			// Read the full response body so we can log it and also re-analyze it
+			bodyBytes, err := io.ReadAll(tokenResp.Body)
 			if err != nil {
-				logging.Error("Failed to read token response", "error", err)
-				return "", fmt.Errorf("failed to read token response: %w", err)
+				return "", fmt.Errorf("failed to read token response body: %w", err)
 			}
-
+			
 			if tokenResp.StatusCode == http.StatusOK {
-				logging.Debug("Received response from GitHub", "response", string(tokenRespBody))
+				// Log the raw response for debugging
+				logging.Debug("Token response body", "body", string(bodyBytes))
 				
-				// Check if we're getting an error response even with 200 status
-				var errorCheck map[string]string
-				if json.Unmarshal(tokenRespBody, &errorCheck) == nil {
-					if errorVal, ok := errorCheck["error"]; ok {
-						logging.Debug("Received error in response", "error", errorVal)
-						if errorVal == "authorization_pending" {
-							logging.Debug("Still waiting for authorization in browser")
-							continue
-						}
-					}
+				// Check for empty or invalid responses
+				if len(bodyBytes) == 0 {
+					logging.Debug("Empty response body from GitHub")
+					continue // Continue polling
 				}
 				
-				var tokenData GitHubTokenResponse
-				if err := json.Unmarshal(tokenRespBody, &tokenData); err != nil {
-					logging.Error("Failed to parse token response", "error", err)
-					return "", fmt.Errorf("failed to parse token response: %w", err)
+				// First try standard OAuth response format
+				var tokenResponse GitHubTokenResponse
+				if err := json.Unmarshal(bodyBytes, &tokenResponse); err != nil {
+					logging.Debug("Failed to parse as standard OAuth format", "error", err)
+					
+					// Try alternative format with access_token field
+					var altResponse struct {
+						AccessToken string `json:"access_token"`
+						TokenType   string `json:"token_type"`
+						Scope       string `json:"scope"`
+					}
+					
+					if err := json.Unmarshal(bodyBytes, &altResponse); err != nil {
+						logging.Debug("Failed to parse in any format", "error", err)
+						continue // Continue polling instead of failing
+					}
+					
+					// Use the alternative format
+					tokenResponse.AccessToken = altResponse.AccessToken
 				}
 
-				logging.Debug("Received token data", "scope", tokenData.Scope)
+				// Check which token field was populated
+				var finalToken string
+				if tokenResponse.AccessToken != "" {
+					finalToken = tokenResponse.AccessToken
+				} else if tokenResponse.Token != "" {
+					finalToken = tokenResponse.Token
+				}
 				
-				if tokenData.AccessToken != "" {
+				// Final token validation
+				if finalToken == "" {
+					logging.Debug("No token found in response")
+					continue // Continue polling instead of failing
+				}
+				
+				if finalToken != "" {
 					fmt.Printf("Successfully authenticated with GitHub!\n")
-					fmt.Printf("Exchanging for Copilot bearer token...\n")
 					
-					// Save the token for future use
-					saveGitHubToken(tokenData.AccessToken)
+					// First set environment variables for immediate use
+					os.Setenv("GITHUB_TOKEN", finalToken)
+					os.Setenv("GITHUB_COPILOT_TOKEN", finalToken)
 					
-					// Set environment variable for immediate use in this session
-					os.Setenv("GITHUB_COPILOT_TOKEN", tokenData.AccessToken)
-					logging.Info("Saved GitHub token and set environment variable for immediate use")
-					
-					// Direct exchange - don't call exchangeGitHubToken to avoid potential loop
-					logging.Debug("Performing direct token exchange for GitHub token")
-					
-					// Create the request to exchange for a Copilot bearer token - use internal API
-					req, err := http.NewRequest("GET", "https://api.github.com/copilot_internal/v2/token", nil)
+					// Save token directly to file
+					homeDir, err := os.UserHomeDir()
 					if err != nil {
-						fmt.Printf("❌ Error creating exchange request: %v\n", err)
-						return "", fmt.Errorf("failed to create exchange request: %w", err)
+						homeDir = os.Getenv("HOME")
 					}
 					
-					req.Header.Set("Authorization", "token "+tokenData.AccessToken) // lowercase "token"
-					req.Header.Set("User-Agent", "GithubCopilot/1.133.0")
-					req.Header.Set("Accept", "application/json")
+					// Set config directory
+					configDir := filepath.Join(homeDir, ".config")
 					
-					fmt.Printf("🔄 Requesting Copilot token from GitHub API...\n")
-					resp, err := c.httpClient.Do(req)
-					if err != nil {
-						fmt.Printf("❌ Exchange request failed: %v\n", err)
-						return "", fmt.Errorf("failed exchange request: %w", err)
-					}
-					defer resp.Body.Close()
-					
-					fmt.Printf("📊 Exchange response status: %d\n", resp.StatusCode)
-					
-					// Check for successful response
-					if resp.StatusCode != http.StatusOK {
-						body, _ := io.ReadAll(resp.Body)
-						fmt.Printf("❌ Token exchange failed: %s\n", string(body))
-						return "", fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+					// Ensure directory exists
+					copilotDir := filepath.Join(configDir, "github-copilot")
+					if err := os.MkdirAll(copilotDir, 0755); err != nil {
+						logging.Error("Failed to create github-copilot directory", "error", err)
 					}
 					
-					// Read the response body
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						fmt.Printf("❌ Failed to read exchange response: %v\n", err)
-						return "", fmt.Errorf("failed to read response: %w", err)
+					// Create hosts.json file
+					hostsFile := filepath.Join(copilotDir, "hosts.json")
+					
+					// Create the JSON structure
+					jsonData := []byte(`{"github.com":{"oauth_token":"` + finalToken + `"}}`)
+					
+					// Write the file
+					if err := os.WriteFile(hostsFile, jsonData, 0600); err != nil {
+						logging.Error("Failed to write hosts.json", "error", err)
+					} else {
+						logging.Info("Saved GitHub token to hosts.json for future use")
 					}
 					
-					// Parse the token response
-					var tokenResp CopilotTokenResponse
-					if err := json.Unmarshal(body, &tokenResp); err != nil {
-						fmt.Printf("❌ Failed to parse exchange response: %v\n", err)
-						return "", fmt.Errorf("failed to parse response: %w", err)
-					}
-					
-					if tokenResp.Token == "" {
-						fmt.Printf("❌ Received empty token from GitHub API\n")
-						return "", fmt.Errorf("received empty token from GitHub API")
-					}
-					
-					// Store the token for future use
-					c.options.bearerToken = tokenResp.Token
-					
-					// Create a new OpenAI client specifically for Copilot with the bearer token
-					baseURL := "https://api.githubcopilot.com"
-					newClient := openai.NewClient(
-						option.WithBaseURL(baseURL),
-						option.WithAPIKey(tokenResp.Token),
-						option.WithHeader("Editor-Version", "OpenCode/1.0"),
-						option.WithHeader("Editor-Plugin-Version", "OpenCode/1.0"),
-						option.WithHeader("Copilot-Integration-Id", "vscode-chat"),
-						option.WithHeader("X-GitHub-Api-Version", "2022-11-28"),
-					)
-					
-					// Replace the client in the current instance
-					c.client = newClient
-					
-					fmt.Printf("✅ Successfully exchanged token for Copilot bearer token!\n")
-					fmt.Printf("✅ Created new OpenAI client for GitHub Copilot\n")
-					fmt.Printf("✅ You can now use OpenCode with GitHub Copilot\n")
-					return tokenResp.Token, nil
+					return finalToken, nil
+				} else {
+					// If we got a 200 but no access token, that's strange
+					logging.Error("Received HTTP 200 but no access token in response", "body", string(bodyBytes))
+					return "", fmt.Errorf("authentication response did not contain an access token")
 				}
 			} else if tokenResp.StatusCode == http.StatusBadRequest {
-				// If it's still pending, continue polling
+				// Check for specific errors
 				var errorResp map[string]string
-				if err := json.Unmarshal(tokenRespBody, &errorResp); err == nil {
+				if err := json.Unmarshal(bodyBytes, &errorResp); err == nil {
 					if errorResp["error"] == "authorization_pending" {
-						// This is normal, just wait for next poll
-						fmt.Printf("⏳ Authorization pending - waiting for you to approve in the browser...\n")
+						// Still waiting for user to authorize - continue
 						continue
 					} else if errorResp["error"] == "slow_down" {
-						// Need to slow down polling
-						interval += 5
-						ticker.Reset(time.Duration(interval) * time.Second)
-						fmt.Printf("⚠️ GitHub asked us to slow down polling. Increased interval to %d seconds.\n", interval)
-						continue
+						// Rate limiting - fail fast
+						return "", fmt.Errorf("GitHub rate limit detected, please try again in a few minutes")
 					} else if errorResp["error"] == "expired_token" {
-						fmt.Printf("❌ Device code expired. Please try again.\n")
 						return "", fmt.Errorf("device code expired, please try again")
-					} else {
-						// Unknown error
-						fmt.Printf("❓ Unknown error from GitHub: %s\n", errorResp["error"])
-						fmt.Printf("❓ Error details: %s\n", string(tokenRespBody))
 					}
-				} else {
-					// Error parsing JSON
-					fmt.Printf("❌ Error parsing response: %v\n", err)
-					fmt.Printf("❌ Raw response: %s\n", string(tokenRespBody))
 				}
-				return "", fmt.Errorf("token request failed with status %d: %s", 
-					tokenResp.StatusCode, string(tokenRespBody))
-			} else {
-				return "", fmt.Errorf("token request failed with status %d: %s", 
-					tokenResp.StatusCode, string(tokenRespBody))
 			}
+			
+			// Any other error
+			return "", fmt.Errorf("token request failed with status %d: %s", 
+				tokenResp.StatusCode, string(bodyBytes))
 
 		case <-ctx.Done():
 			return "", fmt.Errorf("authentication timed out after %d seconds", deviceResp.ExpiresIn)
@@ -515,16 +288,201 @@ func (c *copilotClient) performDeviceCodeFlow() (string, error) {
 	}
 }
 
-// newCopilotClient creates a new client for GitHub Copilot
-// Following the 4-step flow:
-// 1. Check if Copilot is enabled in config (handled by validation)
-// 2. Check for token in config folder
-// 3. If no token, trigger login flow
-// 4. With token ready, open OpenCode normally
-func newCopilotClient(opts providerClientOptions) CopilotClient {
-	logging.Debug("Creating new Copilot client", "model", opts.model)
-	fmt.Printf("🔧 Creating new GitHub Copilot client for model: %s\n", opts.model.ID)
+// saveGitHubToken saves the GitHub token to the standard location for future use
+func saveGitHubToken(token string) {
+	// Only save if we have a token
+	if token == "" {
+		logging.Error("Cannot save empty GitHub token")
+		return
+	}
 	
+	// Get the home directory directly first
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		logging.Error("Failed to get user home directory", "error", err)
+		homeDir = os.Getenv("HOME") // Fallback to HOME environment variable
+		if homeDir == "" {
+			logging.Error("Failed to determine home directory")
+			return
+		}
+	}
+	
+	// Set config directory based on platform
+	var configDir string
+	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
+		configDir = xdgConfig
+		logging.Debug("Using XDG_CONFIG_HOME for config directory", "path", configDir)
+	} else if runtime.GOOS == "windows" {
+		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+			configDir = localAppData
+			logging.Debug("Using LOCALAPPDATA for config directory", "path", configDir)
+		} else {
+			configDir = filepath.Join(homeDir, "AppData", "Local")
+			logging.Debug("Using default Windows AppData path", "path", configDir)
+		}
+	} else {
+		configDir = filepath.Join(homeDir, ".config")
+		logging.Debug("Using default .config directory", "path", configDir)
+	}
+
+	// First try saving to hosts.json (GitHub Copilot VS Code format)
+	hostsResult := saveToHostsFile(configDir, token)
+	
+	// Also try saving to apps.json (Neovim Copilot plugin format) as fallback
+	saveToAppsFile(configDir, token)
+	
+	// Set environment variables for immediate use (even if file saving failed)
+	os.Setenv("GITHUB_TOKEN", token)
+	os.Setenv("GITHUB_COPILOT_TOKEN", token)
+	
+	if !hostsResult {
+		logging.Warn("Failed to save token to hosts.json, but environment variables are set for this session")
+	}
+	
+	return
+}
+
+// saveToHostsFile saves token to hosts.json (VS Code format)
+func saveToHostsFile(configDir string, token string) bool {
+	// Create the directory if it doesn't exist
+	copilotDir := filepath.Join(configDir, "github-copilot")
+	logging.Debug("Using copilot config directory", "path", copilotDir)
+	
+	if err := os.MkdirAll(copilotDir, 0755); err != nil {
+		logging.Error("Failed to create github-copilot directory", "error", err)
+		return false
+	}
+	
+	// Create the hosts.json file
+	hostsFile := filepath.Join(copilotDir, "hosts.json")
+	logging.Debug("Will save hosts file to", "path", hostsFile)
+	
+	// Create the JSON structure
+	hostsData := map[string]map[string]interface{}{
+		"github.com": {
+			"oauth_token": token,
+		},
+	}
+	
+	// Marshal to JSON
+	jsonData, err := json.MarshalIndent(hostsData, "", "  ")
+	if err != nil {
+		logging.Error("Failed to marshal hosts.json", "error", err)
+		return false
+	}
+
+	// First ensure the directory exists
+	if _, err := os.Stat(copilotDir); os.IsNotExist(err) {
+		logging.Debug("Creating directory again to be sure", "path", copilotDir)
+		if err := os.MkdirAll(copilotDir, 0755); err != nil {
+			logging.Error("Failed to create directory during second attempt", "error", err)
+			return false
+		}
+	}
+	
+	// Write the file
+	if err := os.WriteFile(hostsFile, jsonData, 0600); err != nil {
+		logging.Error("Failed to write hosts.json", "error", err)
+		fmt.Printf("⚠️ Failed to save token to %s: %v\n", hostsFile, err)
+		return false
+	}
+	
+	logging.Info("Saved GitHub token to hosts.json for future use")
+	fmt.Printf("✅ Token saved to: %s\n", hostsFile)
+	
+	// Verify file exists and has content
+	if info, err := os.Stat(hostsFile); err == nil {
+		fmt.Printf("✅ Verified file exists, size: %d bytes\n", info.Size())
+		
+		// Double-check file contents
+		content, readErr := os.ReadFile(hostsFile)
+		if readErr != nil {
+			logging.Error("Failed to verify hosts.json contents", "error", readErr)
+			return false
+		}
+		
+		if len(content) == 0 {
+			logging.Error("hosts.json exists but is empty")
+			return false
+		}
+		
+		fmt.Printf("✅ Verified hosts.json has content\n")
+		return true
+	} else {
+		logging.Error("Failed to verify hosts.json exists after writing", "error", err)
+		fmt.Printf("⚠️ Could not verify file: %v\n", err)
+		return false
+	}
+}
+
+// saveToAppsFile saves token to apps.json (Neovim format)
+func saveToAppsFile(configDir string, token string) bool {
+	// Create the directory if it doesn't exist
+	copilotDir := filepath.Join(configDir, "github-copilot")
+	if err := os.MkdirAll(copilotDir, 0755); err != nil {
+		logging.Error("Failed to create github-copilot directory for apps.json", "error", err)
+		return false
+	}
+	
+	// Create the apps.json file (alternative format used by some tools)
+	appsFile := filepath.Join(copilotDir, "apps.json")
+	
+	// Create the JSON structure
+	appsData := map[string]interface{}{
+		"github-copilot/copilot.vim": map[string]interface{}{
+			"oauth_token": token,
+		},
+	}
+	
+	// Marshal to JSON
+	jsonData, err := json.MarshalIndent(appsData, "", "  ")
+	if err != nil {
+		logging.Error("Failed to marshal apps.json", "error", err)
+		return false
+	}
+	
+	// Write the file
+	if err := os.WriteFile(appsFile, jsonData, 0600); err != nil {
+		logging.Error("Failed to write apps.json", "error", err)
+		fmt.Printf("⚠️ Failed to save token to %s: %v\n", appsFile, err)
+		return false
+	}
+	
+	logging.Info("Also saved GitHub token to apps.json for future use")
+	fmt.Printf("✅ Token also saved to: %s\n", appsFile)
+	return true
+}
+
+// exchangeGitHubToken exchanges a GitHub token for a Copilot bearer token
+func (c *copilotClient) exchangeGitHubToken(githubToken string) (string, error) {
+	req, err := http.NewRequest("GET", "https://api.github.com/copilot_internal/v2/token", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create token exchange request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Token "+githubToken)
+	req.Header.Set("User-Agent", "OpenCode/1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to exchange GitHub token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp CopilotTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	return tokenResp.Token, nil
+}
+
+func newCopilotClient(opts providerClientOptions) CopilotClient {
 	copilotOpts := copilotOptions{
 		reasoningEffort: "medium",
 	}
@@ -540,207 +498,130 @@ func newCopilotClient(opts providerClientOptions) CopilotClient {
 
 	var bearerToken string
 
-	// Step 1: Check if Copilot is enabled in config - already done by validation
-
-	// Step 2: Check for token in config folder
-	var githubToken string
-	var useDeviceFlow bool
-	
-	logging.Info("Looking for GitHub Copilot token")
-	fmt.Printf("🔍 Looking for GitHub Copilot authentication token...\n")
-	
 	// If bearer token is already provided, use it
 	if copilotOpts.bearerToken != "" {
-		logging.Debug("Using provided bearer token")
-		fmt.Printf("✅ Using provided bearer token\n")
 		bearerToken = copilotOpts.bearerToken
 	} else {
-		// Check for GitHub token in standard locations
+		// Try to get GitHub token from multiple sources
+		var githubToken string
+
+		// 1. Environment variable
+		githubToken = os.Getenv("GITHUB_TOKEN")
+
+		// 2. API key from options
+		if githubToken == "" {
+			githubToken = opts.apiKey
+		}
+
+		// 3. Standard GitHub CLI/Copilot locations
+		if githubToken == "" {
+			var err error
+			fmt.Printf("🔍 Looking for GitHub Copilot token in standard locations...\n")
+			githubToken, err = config.LoadGitHubToken()
+			if err != nil {
+				// Check if we need to use device flow
+				if err.Error() == "no_copilot_token" && !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
+					logging.Info("No GitHub token found, starting device code flow")
+					fmt.Printf("🔑 No GitHub token found, starting authentication flow...\n")
+					
+					// Create temporary client for auth flow
+					tempClient := &copilotClient{
+						providerOptions: opts,
+						options:         copilotOpts,
+						httpClient:      httpClient,
+					}
+					
+					var authErr error
+					githubToken, authErr = tempClient.performDeviceCodeFlow()
+					if authErr != nil {
+						logging.Error("Device code authentication failed", "error", authErr)
+						fmt.Printf("❌ Authentication failed: %v\n", authErr)
+						return &copilotClient{
+							providerOptions: opts,
+							options:         copilotOpts,
+							httpClient:      httpClient,
+						}
+					}
+					
+					// Double-check token after device flow
+					if githubToken != "" {
+						fmt.Printf("✅ Successfully obtained GitHub token (length: %d)\n", len(githubToken))
+						// Set it directly in opts.apiKey
+						opts.apiKey = githubToken
+						// Also set environment variable
+						os.Setenv("GITHUB_TOKEN", githubToken)
+					}
+				} else {
+					logging.Debug("Failed to load GitHub token from standard locations", "error", err)
+					fmt.Printf("⚠️ Failed to load GitHub token: %v\n", err)
+				}
+			} else if githubToken != "" {
+				fmt.Printf("✅ Found existing GitHub token (length: %d)\n", len(githubToken))
+			}
+		}
+
+		if githubToken == "" {
+			logging.Error("GitHub token is required for Copilot provider. Set GITHUB_TOKEN environment variable, configure it in opencode.json, or ensure GitHub CLI/Copilot is properly authenticated.")
+			return &copilotClient{
+				providerOptions: opts,
+				options:         copilotOpts,
+				httpClient:      httpClient,
+			}
+		}
+
+		// Create a temporary client for token exchange
+		tempClient := &copilotClient{
+			providerOptions: opts,
+			options:         copilotOpts,
+			httpClient:      httpClient,
+		}
+
+		// Exchange GitHub token for bearer token
 		var err error
-		logging.Debug("Checking for GitHub token in standard locations")
-		githubToken, err = config.LoadGitHubToken()
-		
+		fmt.Printf("🔄 Exchanging GitHub token for Copilot bearer token...\n")
+		bearerToken, err = tempClient.exchangeGitHubToken(githubToken)
 		if err != nil {
-			if err.Error() == "no_copilot_token" {
-				// Special error indicating we need device flow
-				useDeviceFlow = true
-				logging.Info("No Copilot token found in config. Need to use device flow.")
-				fmt.Printf("ℹ️ No GitHub Copilot token found in config\n")
-			} else {
-				logging.Error("Failed to load GitHub token", "error", err)
-				fmt.Printf("❌ Error loading GitHub token: %v\n", err)
-			}
-		} else if githubToken != "" {
-			prefixLen := 10
-			if len(githubToken) < prefixLen {
-				prefixLen = len(githubToken)
-			}
-			logging.Debug("Found GitHub token in config", "token_length", len(githubToken), "token_prefix", githubToken[:prefixLen])
-			fmt.Printf("✅ Found GitHub token in config\n")
-		} else {
-			logging.Debug("GitHub token not found in config")
-			fmt.Printf("ℹ️ No GitHub token found in config\n")
-			useDeviceFlow = true
-		}
-		
-		// Step 3: If no token, trigger login flow
-		nonInteractiveFlag := viper.GetBool("non_interactive")
-		cliNonInteractive := viper.GetString("prompt") != ""
-		
-		if useDeviceFlow && !nonInteractiveFlag && !cliNonInteractive {
-			logging.Info("Starting GitHub Copilot authentication flow")
-			fmt.Printf("🔑 Starting GitHub Copilot authentication flow\n")
-			
-			// Create temporary client for auth flow
-			tempClient := &copilotClient{
+			logging.Error("Failed to exchange GitHub token for Copilot bearer token", "error", err)
+			fmt.Printf("❌ Failed to exchange GitHub token: %v\n", err)
+			return &copilotClient{
 				providerOptions: opts,
 				options:         copilotOpts,
 				httpClient:      httpClient,
 			}
-			
-			// Use device code flow to get token
-			var err error
-			githubToken, err = tempClient.performDeviceCodeFlow()
-			if err != nil {
-				logging.Error("Device code authentication failed", "error", err)
-				fmt.Printf("❌ Authentication failed: %v\n", err)
-				
-				// Return dummy client so app doesn't crash
-				return createDummyClient(opts, copilotOpts, httpClient)
-			}
-		} else if useDeviceFlow {
-			// Can't do auth flow in non-interactive mode
-			logging.Error("Authentication required but running in non-interactive mode")
-			fmt.Printf("❌ Authentication required but running in non-interactive mode\n")
-			fmt.Printf("⚠️ Run OpenCode in interactive mode first to authenticate with Copilot\n")
-			
-			// Return dummy client
-			return createDummyClient(opts, copilotOpts, httpClient)
-		}
-		
-		// If we have a GitHub token but no bearer token, exchange for bearer token
-		if githubToken != "" {
-			// Create temporary client for token exchange
-			tempClient := &copilotClient{
-				providerOptions: opts,
-				options:         copilotOpts,
-				httpClient:      httpClient,
-			}
-			
-			// Exchange GitHub token for bearer token
-			var err error
-			logging.Debug("Exchanging GitHub token for Copilot bearer token")
-			fmt.Printf("🔄 Exchanging GitHub token for Copilot bearer token...\n")
-			
-			bearerToken, err = tempClient.exchangeGitHubToken(githubToken)
-			if err != nil {
-				logging.Error("Failed to exchange GitHub token", "error", err)
-				fmt.Printf("❌ Failed to exchange GitHub token: %v\n", err)
-				
-				// Return dummy client
-				return createDummyClient(opts, copilotOpts, httpClient)
-			}
-		} else {
-			// No GitHub token and can't trigger auth flow
-			logging.Error("No GitHub token available and cannot trigger authentication")
-			fmt.Printf("❌ No GitHub token available and cannot trigger authentication\n")
-			
-			// Return dummy client
-			return createDummyClient(opts, copilotOpts, httpClient)
+		} else if bearerToken != "" {
+			fmt.Printf("✅ Successfully obtained Copilot bearer token (length: %d)\n", len(bearerToken))
 		}
 	}
 
 	copilotOpts.bearerToken = bearerToken
 
-	// Step 4: With token ready, create client and proceed with normal operation
-	return createCopilotClient(opts, copilotOpts, httpClient, bearerToken)
-}
-
-// createDummyClient creates a placeholder client when authentication fails
-func createDummyClient(opts providerClientOptions, options copilotOptions, httpClient *http.Client) *copilotClient {
-	logging.Debug("Creating dummy Copilot client due to authentication issues")
-	fmt.Printf("ℹ️ Creating temporary client due to authentication issues\n")
-	
-	dummyClient := openai.NewClient(
-		option.WithBaseURL("https://api.githubcopilot.com"),
-		option.WithAPIKey("dummy-for-initialization"),
-	)
-	
-	return &copilotClient{
-		providerOptions: opts,
-		options:         options,
-		client:          dummyClient,
-		httpClient:      httpClient,
-	}
-}
-
-// createCopilotClient creates a fully configured client for GitHub Copilot
-func createCopilotClient(opts providerClientOptions, options copilotOptions, httpClient *http.Client, bearerToken string) *copilotClient {
 	// GitHub Copilot API base URL
 	baseURL := "https://api.githubcopilot.com"
-	customURL := viper.GetString("providers.copilot.baseUrl")
-	if customURL != "" {
-		logging.Debug("Using custom baseUrl for Copilot from config", "baseUrl", customURL)
-		fmt.Printf("🌐 Using custom baseUrl for Copilot: %s\n", customURL)
-		baseURL = customURL
-	}
-	
-	// Make sure baseURL is set
-	if baseURL == "" {
-		logging.Error("Missing baseURL for Copilot client")
-		fmt.Printf("❌ Missing baseURL for Copilot client\n")
-		return createDummyClient(opts, options, httpClient)
-	}
-	
-	// If no bearer token, return dummy client
-	if bearerToken == "" {
-		logging.Error("No bearer token available for Copilot client")
-		return createDummyClient(opts, options, httpClient)
-	}
 
-	// Create the proper client with all required options and headers
-	prefixLen := 10
-	if len(bearerToken) < prefixLen {
-		prefixLen = len(bearerToken)
-	}
-	logging.Debug("Creating Copilot client with valid bearer token", 
-		"baseURL", baseURL, 
-		"model", opts.model.APIModel, 
-		"token_length", len(bearerToken),
-		"bearerToken_prefix", bearerToken[:prefixLen])
-	fmt.Printf("✅ Creating Copilot client with valid bearer token\n")
-	
-	// Create OpenAI client with all required settings for Copilot
 	openaiClientOptions := []option.RequestOption{
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey(bearerToken), // Use bearer token as API key
-		option.WithHeader("User-Agent", "GithubCopilot/1.133.0"),
-		option.WithHeader("Editor-Version", "vscode/1.78.0"),
-		option.WithHeader("Editor-Plugin-Version", "copilot-chat/0.8.0"),
-		option.WithHeader("Accept", "application/json"),
-		option.WithHeader("X-GitHub-Api-Version", "2022-11-28"), // Required GitHub API version
 	}
 
-	// Add any extra headers from options
-	if options.extraHeaders != nil {
-		for key, value := range options.extraHeaders {
+	// Add GitHub Copilot specific headers
+	openaiClientOptions = append(openaiClientOptions,
+		option.WithHeader("Editor-Version", "OpenCode/1.0"),
+		option.WithHeader("Editor-Plugin-Version", "OpenCode/1.0"),
+		option.WithHeader("Copilot-Integration-Id", "vscode-chat"),
+	)
+
+	// Add any extra headers
+	if copilotOpts.extraHeaders != nil {
+		for key, value := range copilotOpts.extraHeaders {
 			openaiClientOptions = append(openaiClientOptions, option.WithHeader(key, value))
 		}
 	}
 
-	// Create client with proper headers
 	client := openai.NewClient(openaiClientOptions...)
-	fmt.Printf("✅ GitHub Copilot client created successfully\n")
-	fmt.Printf("✅ Using model: %s (%s)\n", opts.model.Name, opts.model.APIModel)
-	
-	// Create and return the copilotClient
+	// logging.Debug("Copilot client created", "opts", opts, "copilotOpts", copilotOpts, "model", opts.model)
 	return &copilotClient{
 		providerOptions: opts,
-		options: copilotOptions{
-			reasoningEffort: options.reasoningEffort,
-			extraHeaders: options.extraHeaders,
-			bearerToken: bearerToken,
-		},
+		options:         copilotOpts,
 		client:          client,
 		httpClient:      httpClient,
 	}
@@ -841,30 +722,8 @@ func (c *copilotClient) finishReason(reason string) message.FinishReason {
 }
 
 func (c *copilotClient) preparedParams(messages []openai.ChatCompletionMessageParamUnion, tools []openai.ChatCompletionToolParam) openai.ChatCompletionNewParams {
-	logging.Debug("Copilot preparedParams start", "modelID", c.providerOptions.model.ID, "apiModel", c.providerOptions.model.APIModel)
-	
-	// For Claude models, use the proper model name format
-	apiModel := c.providerOptions.model.APIModel
-	if c.isAnthropicModel() {
-		logging.Debug("Using Claude model", "original_api_model", apiModel)
-		fmt.Printf("📢 Using Claude model: %s through GitHub Copilot\n", apiModel)
-		// The Claude models might need a special format for Copilot
-		if strings.HasPrefix(apiModel, "claude-") {
-			logging.Debug("Using Claude model with standard format", "api_model", apiModel)
-			fmt.Printf("📢 Claude model name format: %s\n", apiModel)
-		}
-	} else {
-		fmt.Printf("📢 Using non-Claude model: %s through GitHub Copilot\n", apiModel)
-	}
-	
-	// Log important model details
-	logging.Debug("Model details", 
-		"name", c.providerOptions.model.Name,
-		"context_window", c.providerOptions.model.ContextWindow,
-		"max_tokens", c.providerOptions.maxTokens)
-	
 	params := openai.ChatCompletionNewParams{
-		Model:    openai.ChatModel(apiModel),
+		Model:    openai.ChatModel(c.providerOptions.model.APIModel),
 		Messages: messages,
 		Tools:    tools,
 	}
@@ -885,10 +744,6 @@ func (c *copilotClient) preparedParams(messages []openai.ChatCompletionMessagePa
 		params.MaxTokens = openai.Int(c.providerOptions.maxTokens)
 	}
 
-	jsonData, err := json.Marshal(params)
-	if err == nil {
-		logging.Debug("Copilot request parameters", "params", string(jsonData))
-	}
 	return params
 }
 
@@ -897,81 +752,36 @@ func (c *copilotClient) send(ctx context.Context, messages []message.Message, to
 	cfg := config.Get()
 	var sessionId string
 	requestSeqId := (len(messages) + 1) / 2
-	
-	// Always log parameters in debug mode
-	jsonData, _ := json.Marshal(params)
-	logging.Debug("Copilot API request parameters", "model", params.Model, "messages_count", len(params.Messages), "tools_count", len(params.Tools))
-	logging.Debug("Copilot API full request", "params", string(jsonData))
-	logging.Debug("Model being used for request", "model_id", c.providerOptions.model.ID, "api_model", c.providerOptions.model.APIModel)
-	
 	if cfg.Debug {
+		// jsonData, _ := json.Marshal(params)
+		// logging.Debug("Prepared messages", "messages", string(jsonData))
 		if sid, ok := ctx.Value(toolsPkg.SessionIDContextKey).(string); ok {
 			sessionId = sid
 		}
+		jsonData, _ := json.Marshal(params)
 		if sessionId != "" {
 			filepath := logging.WriteRequestMessageJson(sessionId, requestSeqId, params)
 			logging.Debug("Prepared messages", "filepath", filepath)
+		} else {
+			logging.Debug("Prepared messages", "messages", string(jsonData))
 		}
 	}
 
 	attempts := 0
 	for {
 		attempts++
-		fmt.Printf("🔄 Sending request to GitHub Copilot API...\n")
-		logging.Debug("About to send Copilot API request", "model", string(params.Model), "max_tokens_param", params.MaxTokens, "max_completion_tokens_param", params.MaxCompletionTokens, "tools_count", len(tools))
-		logging.Debug("Sending request to Copilot API", "baseURL", "https://api.githubcopilot.com", "model", params.Model)
-		
-		// Dump headers for debugging
-		logging.Debug("Request is being made with OpenAI client", "client_type", fmt.Sprintf("%T", c.client))
-		fmt.Printf("📋 Making request with client: %T\n", c.client)
-		
-		// Dump important request parameters
-		fmt.Printf("📋 Request model: %s\n", params.Model)
-		fmt.Printf("📋 Request max tokens: %d\n", c.providerOptions.maxTokens)
-		
-		// Make the API request
 		copilotResponse, err := c.client.Chat.Completions.New(
 			ctx,
 			params,
 		)
-		logging.Debug("Received response from Copilot API", "error", err != nil)
 
 		// If there is an error we are going to see if we can retry the call
 		if err != nil {
-			fmt.Printf("❌ Copilot API request failed: %v\n", err)
-			logging.Error("Copilot API request failed", "error", err)
-			var apierr *openai.Error
-			if errors.As(err, &apierr) {
-				fmt.Printf("❌ API Error: Status %d, Type %s\n", apierr.StatusCode, apierr.Type)
-				fmt.Printf("❌ Error Response: %s\n", apierr.RawJSON())
-				logging.Error("Copilot API error details", "status", apierr.StatusCode, "type", apierr.Type, "raw_json", apierr.RawJSON())
-				
-				// Check if this is a model not found error
-				if apierr.StatusCode == 400 {
-					if strings.Contains(string(apierr.RawJSON()), "model") {
-						fmt.Printf("⚠️ This might be because the model '%s' is not available or not supported by GitHub Copilot.\n", params.Model)
-						fmt.Printf("⚠️ Automatically trying 'copilot.gpt-4o' instead...\n")
-						
-						// If this was a Claude model, try with GPT-4o as fallback
-						if c.isAnthropicModel() && attempts < 2 {
-							logging.Info("Trying with GPT-4o model instead of Claude")
-							params.Model = "gpt-4o"
-							continue
-						} else {
-							fmt.Printf("⚠️ Try manually changing your config to use 'copilot.gpt-4o' instead.\n")
-						}
-					}
-				}
-			}
-			
 			retry, after, retryErr := c.shouldRetry(attempts, err)
 			if retryErr != nil {
-				fmt.Printf("❌ Cannot retry: %v\n", retryErr)
-				logging.Error("Retry error", "error", retryErr)
 				return nil, retryErr
 			}
 			if retry {
-				fmt.Printf("⏳ Retrying in %d ms (attempt %d of %d)...\n", after, attempts, maxRetries)
 				logging.WarnPersist(fmt.Sprintf("Retrying due to rate limit... attempt %d of %d", attempts, maxRetries), logging.PersistTimeArg, time.Millisecond*time.Duration(after+100))
 				select {
 				case <-ctx.Done():
@@ -981,8 +791,6 @@ func (c *copilotClient) send(ctx context.Context, messages []message.Message, to
 				}
 			}
 			return nil, retryErr
-		} else {
-			fmt.Printf("✅ Successful response from GitHub Copilot API!\n")
 		}
 
 		content := ""
@@ -1212,17 +1020,6 @@ func (c *copilotClient) shouldRetry(attempts int, err error) (bool, int64, error
 				// Note: This is a simplified approach. In a production system,
 				// you might want to recreate the entire client with the new token
 				logging.Info("Refreshed Copilot bearer token")
-				
-				// Recreate the entire client with the new token
-				baseURL := "https://api.githubcopilot.com"
-				c.client = openai.NewClient(
-					option.WithBaseURL(baseURL),
-					option.WithAPIKey(newBearerToken),
-					option.WithHeader("Editor-Version", "OpenCode/1.0"),
-					option.WithHeader("Editor-Plugin-Version", "OpenCode/1.0"),
-					option.WithHeader("Copilot-Integration-Id", "vscode-chat"),
-				)
-				
 				return true, 1000, nil // Retry immediately with new token
 			}
 			logging.Error("Failed to refresh Copilot bearer token", "error", tokenErr)
@@ -1231,14 +1028,7 @@ func (c *copilotClient) shouldRetry(attempts int, err error) (bool, int64, error
 	}
 	logging.Debug("Copilot API Error", "status", apierr.StatusCode, "headers", apierr.Response.Header, "body", apierr.RawJSON())
 
-	if apierr.StatusCode == 400 {
-		// Special handling for 400 Bad Request
-		logging.Error("Copilot API 400 Bad Request error", "error", err.Error(), "response_body", apierr.RawJSON())
-		
-		// Try to extract more details from the error
-		detailedErr := fmt.Errorf("Copilot API 400 Bad Request: %s", apierr.Error())
-		return false, 0, detailedErr
-	} else if apierr.StatusCode != 429 && apierr.StatusCode != 500 {
+	if apierr.StatusCode != 429 && apierr.StatusCode != 500 {
 		return false, 0, err
 	}
 
@@ -1319,3 +1109,4 @@ func WithCopilotBearerToken(bearerToken string) CopilotOption {
 		options.bearerToken = bearerToken
 	}
 }
+

--- a/internal/llm/provider/copilot.go
+++ b/internal/llm/provider/copilot.go
@@ -314,8 +314,7 @@ func saveGitHubToken(token string) {
 		}
 	}
 	
-	// Set environment variables for immediate use
-	os.Setenv("GITHUB_TOKEN", token)
+	// Set environment variables for immediate use (only GITHUB_COPILOT_TOKEN)
 	os.Setenv("GITHUB_COPILOT_TOKEN", token)
 }
 
@@ -371,12 +370,9 @@ func newCopilotClient(opts providerClientOptions) CopilotClient {
 		// Try to get GitHub token from multiple sources
 		var githubToken string
 
-		// 1. Check environment variables first (fastest)
-		for _, envVar := range []string{"GITHUB_TOKEN", "GITHUB_COPILOT_TOKEN", "GH_COPILOT_TOKEN"} {
-			if token := os.Getenv(envVar); token != "" {
-				githubToken = token
-				break
-			}
+		// 1. Check GITHUB_COPILOT_TOKEN environment variable first
+		if token := os.Getenv("GITHUB_COPILOT_TOKEN"); token != "" {
+			githubToken = token
 		}
 
 		// 2. API key from options
@@ -430,7 +426,7 @@ func newCopilotClient(opts providerClientOptions) CopilotClient {
 		}
 
 		if githubToken == "" {
-			logging.Error("GitHub token is required for Copilot provider. Set GITHUB_TOKEN environment variable, configure it in opencode.json, or ensure GitHub CLI/Copilot is properly authenticated.")
+			logging.Error("GitHub Copilot token is required for Copilot provider. Set GITHUB_COPILOT_TOKEN environment variable, configure it in opencode.json, or ensure GitHub Copilot is properly authenticated.")
 			return &copilotClient{
 				providerOptions: opts,
 				options:         copilotOpts,
@@ -864,8 +860,8 @@ func (c *copilotClient) shouldRetry(attempts int, err error) (bool, int64, error
 		// Try to refresh the bearer token
 		var githubToken string
 
-		// 1. Environment variable
-		githubToken = os.Getenv("GITHUB_TOKEN")
+		// 1. Check GITHUB_COPILOT_TOKEN environment variable
+		githubToken = os.Getenv("GITHUB_COPILOT_TOKEN")
 
 		// 2. API key from options
 		if githubToken == "" {

--- a/internal/llm/provider/copilot.go
+++ b/internal/llm/provider/copilot.go
@@ -7,7 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/openai/openai-go"
@@ -18,6 +22,7 @@ import (
 	toolsPkg "github.com/opencode-ai/opencode/internal/llm/tools"
 	"github.com/opencode-ai/opencode/internal/logging"
 	"github.com/opencode-ai/opencode/internal/message"
+	"github.com/spf13/viper"
 )
 
 type copilotOptions struct {
@@ -52,13 +57,10 @@ func (c *copilotClient) isAnthropicModel() bool {
 	return false
 }
 
-// loadGitHubToken loads the GitHub OAuth token from the standard GitHub CLI/Copilot locations
-
-// exchangeGitHubToken exchanges a GitHub token for a Copilot bearer token
-func (c *copilotClient) exchangeGitHubToken(githubToken string) (string, error) {
-	req, err := http.NewRequest("GET", "https://api.github.com/copilot_internal/v2/token", nil)
+func (c *copilotClient) getGitHubTokenScopes(githubToken string) (string, error) {
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create token exchange request: %w", err)
+		return "", fmt.Errorf("failed to create GitHub API request: %w", err)
 	}
 
 	req.Header.Set("Authorization", "Token "+githubToken)
@@ -66,24 +68,467 @@ func (c *copilotClient) exchangeGitHubToken(githubToken string) (string, error) 
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to exchange GitHub token: %w", err)
+		return "", fmt.Errorf("failed to query GitHub API: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("GitHub API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	var tokenResp CopilotTokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return "", fmt.Errorf("failed to decode token response: %w", err)
-	}
-
-	return tokenResp.Token, nil
+	scopes := resp.Header.Get("X-OAuth-Scopes")
+	return scopes, nil
 }
 
+// GitHub OAuth device flow response
+type GitHubDeviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// GitHub OAuth token response
+type GitHubTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope"`
+}
+
+// exchangeGitHubToken exchanges a GitHub token for a Copilot bearer token
+// If the token is provided, it will try to use it directly
+// Otherwise, it will start the GitHub device code flow
+func (c *copilotClient) exchangeGitHubToken(githubToken string) (string, error) {
+	// If a token is provided, try to use it directly
+	if githubToken != "" {
+		prefixLen := 10
+		if len(githubToken) < prefixLen {
+			prefixLen = len(githubToken)
+		}
+		logging.Debug("Exchanging GitHub token", "token_length", len(githubToken), "token_prefix", githubToken[:prefixLen])
+
+		// Check GitHub token scopes first to verify it's a valid token
+		scopes, err := c.getGitHubTokenScopes(githubToken)
+		if err != nil {
+			logging.Error("Failed to get GitHub token scopes", "error", err)
+			// If we can't verify token scopes, just continue - the token exchange will fail if invalid
+		} else {
+			logging.Debug("GitHub token scopes", "scopes", scopes)
+			if !strings.Contains(scopes, "copilot") {
+				logging.Warn("GitHub token does not have copilot scope - token exchange may fail")
+			}
+		}
+
+		// Attempt to exchange for a Copilot bearer token - match VS Code exactly
+		req, err := http.NewRequest("GET", "https://api.github.com/copilot_internal/v2/token", nil)
+		if err != nil {
+			return "", fmt.Errorf("failed to create token exchange request: %w", err)
+		}
+
+		req.Header.Set("Authorization", "token "+githubToken) // Note: "token" not "Token"
+		req.Header.Set("User-Agent", "GithubCopilot/1.133.0")
+		req.Header.Set("Accept", "application/json")
+
+		logging.Debug("Sending token exchange request to GitHub API")
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			logging.Error("Failed HTTP request for token exchange", "error", err)
+			// If we're not in non-interactive mode, try device flow
+			if !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
+				logging.Info("Token exchange HTTP request failed, falling back to device code flow")
+				return c.performDeviceCodeFlow()
+			}
+			return "", fmt.Errorf("failed to exchange GitHub token: %w", err)
+		}
+		defer resp.Body.Close()
+
+		logging.Debug("Token exchange response received", "status", resp.StatusCode, "headers", resp.Header)
+		
+		// Check for HTTP errors
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			logging.Error("Token exchange failed", "status_code", resp.StatusCode, "body", string(body))
+			
+			// If we're not in non-interactive mode, try device flow
+			if !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
+				logging.Info("Token exchange failed, falling back to device code flow")
+				return c.performDeviceCodeFlow()
+			}
+			return "", fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+		}
+
+		// Success! Read the response
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			logging.Error("Failed to read token response body", "error", err)
+			return "", fmt.Errorf("failed to read token response: %w", err)
+		}
+
+		logging.Debug("Token exchange response body received, length", "bytes", len(body))
+		
+		var tokenResp CopilotTokenResponse
+		if err := json.Unmarshal(body, &tokenResp); err != nil {
+			logging.Error("Failed to decode token response", "error", err)
+			return "", fmt.Errorf("failed to decode token response: %w", err)
+		}
+
+		if tokenResp.Token == "" {
+			logging.Error("Received empty token from GitHub API")
+			
+			// If we're not in non-interactive mode, try device flow
+			if !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
+				logging.Info("Received empty token, falling back to device code flow")
+				return c.performDeviceCodeFlow()
+			}
+			return "", fmt.Errorf("received empty token from GitHub API")
+		}
+
+		prefixLen = 10
+		if len(tokenResp.Token) < prefixLen {
+			prefixLen = len(tokenResp.Token)
+		}
+		logging.Debug("Successfully obtained Copilot bearer token", 
+			"token_prefix", tokenResp.Token[:prefixLen], 
+			"expires_at", tokenResp.ExpiresAt)
+			
+		// Try saving the token for future use
+		saveGitHubToken(githubToken)
+			
+		return tokenResp.Token, nil
+	} else {
+		// No token provided, use device code flow if we're not in non-interactive mode
+		if !viper.GetBool("non_interactive") && viper.GetString("prompt") == "" {
+			logging.Info("No GitHub token provided, starting device code flow")
+			return c.performDeviceCodeFlow()
+		}
+		return "", fmt.Errorf("no GitHub token available and running in non-interactive mode")
+	}
+}
+
+// saveGitHubToken saves the GitHub token to the standard location for future use
+func saveGitHubToken(token string) {
+	// Only save if we have a token
+	if token == "" {
+		return
+	}
+	
+	// Get the config directory
+	var configDir string
+	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
+		configDir = xdgConfig
+	} else if runtime.GOOS == "windows" {
+		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+			configDir = localAppData
+		} else {
+			configDir = filepath.Join(os.Getenv("HOME"), "AppData", "Local")
+		}
+	} else {
+		configDir = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+	
+	// Create the directory if it doesn't exist
+	copilotDir := filepath.Join(configDir, "github-copilot")
+	if err := os.MkdirAll(copilotDir, 0755); err != nil {
+		logging.Error("Failed to create github-copilot directory", "error", err)
+		return
+	}
+	
+	// Create the hosts.json file
+	hostsFile := filepath.Join(copilotDir, "hosts.json")
+	
+	// Create the JSON structure
+	hostsData := map[string]map[string]interface{}{
+		"github.com": {
+			"oauth_token": token,
+		},
+	}
+	
+	// Marshal to JSON
+	jsonData, err := json.MarshalIndent(hostsData, "", "  ")
+	if err != nil {
+		logging.Error("Failed to marshal hosts.json", "error", err)
+		return
+	}
+	
+	// Write the file
+	if err := os.WriteFile(hostsFile, jsonData, 0600); err != nil {
+		logging.Error("Failed to write hosts.json", "error", err)
+		return
+	}
+	
+	logging.Info("Saved GitHub token to hosts.json for future use", "path", hostsFile)
+}
+
+// performDeviceCodeFlow initiates the GitHub device code flow and returns a Copilot bearer token
+func (c *copilotClient) performDeviceCodeFlow() (string, error) {
+	// Step 1: Get a device code
+	data := url.Values{}
+	
+	// Use the official GitHub Copilot client ID
+	// This is used by multiple Copilot integrations including Neovim
+	// The client ID is publicly visible in VS Code and Neovim plugins
+	const copilotClientID = "Iv1.b507a08c87ecfe98"
+	data.Set("client_id", copilotClientID)
+	data.Set("scope", "user:email read:user copilot")
+	
+	fmt.Printf("🔐 Using GitHub Copilot client ID: %s\n", copilotClientID)
+	fmt.Printf("🔐 Requesting device code for scopes: user:email read:user copilot\n")
+
+	// Using the exact URL and headers from VS Code Copilot extension
+	req, err := http.NewRequest("POST", "https://github.com/login/device/code", strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create device code request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "OpenCode/1.0")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get device code: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("device code request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read device code response: %w", err)
+	}
+
+	var deviceResp GitHubDeviceCodeResponse
+	if err := json.Unmarshal(body, &deviceResp); err != nil {
+		return "", fmt.Errorf("failed to parse device code response: %w", err)
+	}
+
+	// Step 2: Print instructions for the user
+	fmt.Printf("\n🔑 GitHub Copilot Authentication Required\n\n")
+	fmt.Printf("1. Visit: %s\n", deviceResp.VerificationURI)
+	fmt.Printf("2. Enter code: %s\n\n", deviceResp.UserCode)
+	fmt.Printf("Waiting for authentication... (expires in %d seconds)\n", deviceResp.ExpiresIn)
+	fmt.Printf("Please complete authentication in your browser to continue.\n\n")
+
+	// Step 3: Poll for the token
+	tokenData := url.Values{}
+	tokenData.Set("client_id", copilotClientID) // Use the same client ID as before
+	tokenData.Set("device_code", deviceResp.DeviceCode)
+	tokenData.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+
+	// Add a slight delay before first poll
+	time.Sleep(2 * time.Second)
+
+	// Create a context with timeout based on expires_in
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(deviceResp.ExpiresIn)*time.Second)
+	defer cancel()
+
+	interval := deviceResp.Interval
+	if interval < 5 {
+		interval = 5 // Ensure minimum polling interval
+	}
+
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	defer ticker.Stop()
+
+	fmt.Printf("⏳ Waiting for you to authorize the device...\n")
+	pollAttempts := 0
+	
+	for {
+		select {
+		case <-ticker.C:
+			pollAttempts++
+			fmt.Printf("🔄 Checking authorization status... (attempt %d)\n", pollAttempts)
+			
+			// Make a request to check if the user has authorized
+			tokenReq, err := http.NewRequest("POST", "https://github.com/login/oauth/access_token", 
+				strings.NewReader(tokenData.Encode()))
+			if err != nil {
+				fmt.Printf("❌ Error creating token request: %v\n", err)
+				return "", fmt.Errorf("failed to create token request: %w", err)
+			}
+
+			tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			tokenReq.Header.Set("User-Agent", "OpenCode/1.0")
+			tokenReq.Header.Set("Accept", "application/json")
+
+			tokenResp, err := c.httpClient.Do(tokenReq)
+			if err != nil {
+				fmt.Printf("❌ Error making token request: %v\n", err)
+				return "", fmt.Errorf("failed token request: %w", err)
+			}
+
+			fmt.Printf("📊 Token poll response status: %d\n", tokenResp.StatusCode)
+			
+			tokenRespBody, err := io.ReadAll(tokenResp.Body)
+			tokenResp.Body.Close()
+			if err != nil {
+				fmt.Printf("❌ Error reading token response: %v\n", err)
+				return "", fmt.Errorf("failed to read token response: %w", err)
+			}
+
+			if tokenResp.StatusCode == http.StatusOK {
+				fmt.Printf("✅ Received response from GitHub. Processing...\n")
+				fmt.Printf("📃 Raw response: %s\n", string(tokenRespBody))
+				
+				// Check if we're getting an error response even with 200 status
+				var errorCheck map[string]string
+				if json.Unmarshal(tokenRespBody, &errorCheck) == nil {
+					if errorVal, ok := errorCheck["error"]; ok {
+						fmt.Printf("⚠️ Received error with 200 status: %s\n", errorVal)
+						if errorVal == "authorization_pending" {
+							fmt.Printf("⏳ Still waiting for authorization in browser...\n")
+							continue
+						}
+					}
+				}
+				
+				var tokenData GitHubTokenResponse
+				if err := json.Unmarshal(tokenRespBody, &tokenData); err != nil {
+					fmt.Printf("❌ Error parsing token response: %v\n", err)
+					return "", fmt.Errorf("failed to parse token response: %w", err)
+				}
+
+				fmt.Printf("✅ Token data: %+v\n", tokenData)
+				
+				if tokenData.AccessToken != "" {
+					fmt.Printf("✅ Successfully authenticated with GitHub!\n")
+					fmt.Printf("✅ Token received and stored for future use\n")
+					fmt.Printf("✅ Now exchanging for Copilot bearer token...\n")
+					
+					// Save the token for future use
+					saveGitHubToken(tokenData.AccessToken)
+					
+					// Set environment variable for immediate use in this session
+					os.Setenv("GITHUB_COPILOT_TOKEN", tokenData.AccessToken)
+					logging.Info("Saved GitHub token and set environment variable for immediate use")
+					
+					// Direct exchange - don't call exchangeGitHubToken to avoid potential loop
+					logging.Debug("Performing direct token exchange for GitHub token")
+					
+					// Create the request to exchange for a Copilot bearer token - use internal API
+					req, err := http.NewRequest("GET", "https://api.github.com/copilot_internal/v2/token", nil)
+					if err != nil {
+						fmt.Printf("❌ Error creating exchange request: %v\n", err)
+						return "", fmt.Errorf("failed to create exchange request: %w", err)
+					}
+					
+					req.Header.Set("Authorization", "token "+tokenData.AccessToken) // lowercase "token"
+					req.Header.Set("User-Agent", "GithubCopilot/1.133.0")
+					req.Header.Set("Accept", "application/json")
+					
+					fmt.Printf("🔄 Requesting Copilot token from GitHub API...\n")
+					resp, err := c.httpClient.Do(req)
+					if err != nil {
+						fmt.Printf("❌ Exchange request failed: %v\n", err)
+						return "", fmt.Errorf("failed exchange request: %w", err)
+					}
+					defer resp.Body.Close()
+					
+					fmt.Printf("📊 Exchange response status: %d\n", resp.StatusCode)
+					
+					// Check for successful response
+					if resp.StatusCode != http.StatusOK {
+						body, _ := io.ReadAll(resp.Body)
+						fmt.Printf("❌ Token exchange failed: %s\n", string(body))
+						return "", fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+					}
+					
+					// Read the response body
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						fmt.Printf("❌ Failed to read exchange response: %v\n", err)
+						return "", fmt.Errorf("failed to read response: %w", err)
+					}
+					
+					// Parse the token response
+					var tokenResp CopilotTokenResponse
+					if err := json.Unmarshal(body, &tokenResp); err != nil {
+						fmt.Printf("❌ Failed to parse exchange response: %v\n", err)
+						return "", fmt.Errorf("failed to parse response: %w", err)
+					}
+					
+					if tokenResp.Token == "" {
+						fmt.Printf("❌ Received empty token from GitHub API\n")
+						return "", fmt.Errorf("received empty token from GitHub API")
+					}
+					
+					// Store the token for future use
+					c.options.bearerToken = tokenResp.Token
+					
+					// Create a new OpenAI client specifically for Copilot with the bearer token
+					baseURL := "https://api.githubcopilot.com"
+					newClient := openai.NewClient(
+						option.WithBaseURL(baseURL),
+						option.WithAPIKey(tokenResp.Token),
+						option.WithHeader("Editor-Version", "OpenCode/1.0"),
+						option.WithHeader("Editor-Plugin-Version", "OpenCode/1.0"),
+						option.WithHeader("Copilot-Integration-Id", "vscode-chat"),
+						option.WithHeader("X-GitHub-Api-Version", "2022-11-28"),
+					)
+					
+					// Replace the client in the current instance
+					c.client = newClient
+					
+					fmt.Printf("✅ Successfully exchanged token for Copilot bearer token!\n")
+					fmt.Printf("✅ Created new OpenAI client for GitHub Copilot\n")
+					fmt.Printf("✅ You can now use OpenCode with GitHub Copilot\n")
+					return tokenResp.Token, nil
+				}
+			} else if tokenResp.StatusCode == http.StatusBadRequest {
+				// If it's still pending, continue polling
+				var errorResp map[string]string
+				if err := json.Unmarshal(tokenRespBody, &errorResp); err == nil {
+					if errorResp["error"] == "authorization_pending" {
+						// This is normal, just wait for next poll
+						fmt.Printf("⏳ Authorization pending - waiting for you to approve in the browser...\n")
+						continue
+					} else if errorResp["error"] == "slow_down" {
+						// Need to slow down polling
+						interval += 5
+						ticker.Reset(time.Duration(interval) * time.Second)
+						fmt.Printf("⚠️ GitHub asked us to slow down polling. Increased interval to %d seconds.\n", interval)
+						continue
+					} else if errorResp["error"] == "expired_token" {
+						fmt.Printf("❌ Device code expired. Please try again.\n")
+						return "", fmt.Errorf("device code expired, please try again")
+					} else {
+						// Unknown error
+						fmt.Printf("❓ Unknown error from GitHub: %s\n", errorResp["error"])
+						fmt.Printf("❓ Error details: %s\n", string(tokenRespBody))
+					}
+				} else {
+					// Error parsing JSON
+					fmt.Printf("❌ Error parsing response: %v\n", err)
+					fmt.Printf("❌ Raw response: %s\n", string(tokenRespBody))
+				}
+				return "", fmt.Errorf("token request failed with status %d: %s", 
+					tokenResp.StatusCode, string(tokenRespBody))
+			} else {
+				return "", fmt.Errorf("token request failed with status %d: %s", 
+					tokenResp.StatusCode, string(tokenRespBody))
+			}
+
+		case <-ctx.Done():
+			return "", fmt.Errorf("authentication timed out after %d seconds", deviceResp.ExpiresIn)
+		}
+	}
+}
+
+// newCopilotClient creates a new client for GitHub Copilot
+// Following the 4-step flow:
+// 1. Check if Copilot is enabled in config (handled by validation)
+// 2. Check for token in config folder
+// 3. If no token, trigger login flow
+// 4. With token ready, open OpenCode normally
 func newCopilotClient(opts providerClientOptions) CopilotClient {
+	logging.Debug("Creating new Copilot client", "model", opts.model)
+	fmt.Printf("🔧 Creating new GitHub Copilot client for model: %s\n", opts.model.ID)
+	
 	copilotOpts := copilotOptions{
 		reasoningEffort: "medium",
 	}
@@ -99,88 +544,207 @@ func newCopilotClient(opts providerClientOptions) CopilotClient {
 
 	var bearerToken string
 
+	// Step 1: Check if Copilot is enabled in config - already done by validation
+
+	// Step 2: Check for token in config folder
+	var githubToken string
+	var useDeviceFlow bool
+	
+	logging.Info("Looking for GitHub Copilot token")
+	fmt.Printf("🔍 Looking for GitHub Copilot authentication token...\n")
+	
 	// If bearer token is already provided, use it
 	if copilotOpts.bearerToken != "" {
+		logging.Debug("Using provided bearer token")
+		fmt.Printf("✅ Using provided bearer token\n")
 		bearerToken = copilotOpts.bearerToken
 	} else {
-		// Try to get GitHub token from multiple sources
-		var githubToken string
-
-		// 1. Environment variable
-		githubToken = os.Getenv("GITHUB_TOKEN")
-
-		// 2. API key from options
-		if githubToken == "" {
-			githubToken = opts.apiKey
-		}
-
-		// 3. Standard GitHub CLI/Copilot locations
-		if githubToken == "" {
-			var err error
-			githubToken, err = config.LoadGitHubToken()
-			if err != nil {
-				logging.Debug("Failed to load GitHub token from standard locations", "error", err)
-			}
-		}
-
-		if githubToken == "" {
-			logging.Error("GitHub token is required for Copilot provider. Set GITHUB_TOKEN environment variable, configure it in opencode.json, or ensure GitHub CLI/Copilot is properly authenticated.")
-			return &copilotClient{
-				providerOptions: opts,
-				options:         copilotOpts,
-				httpClient:      httpClient,
-			}
-		}
-
-		// Create a temporary client for token exchange
-		tempClient := &copilotClient{
-			providerOptions: opts,
-			options:         copilotOpts,
-			httpClient:      httpClient,
-		}
-
-		// Exchange GitHub token for bearer token
+		// Check for GitHub token in standard locations
 		var err error
-		bearerToken, err = tempClient.exchangeGitHubToken(githubToken)
+		logging.Debug("Checking for GitHub token in standard locations")
+		githubToken, err = config.LoadGitHubToken()
+		
 		if err != nil {
-			logging.Error("Failed to exchange GitHub token for Copilot bearer token", "error", err)
-			return &copilotClient{
+			if err.Error() == "no_copilot_token" {
+				// Special error indicating we need device flow
+				useDeviceFlow = true
+				logging.Info("No Copilot token found in config. Need to use device flow.")
+				fmt.Printf("ℹ️ No GitHub Copilot token found in config\n")
+			} else {
+				logging.Error("Failed to load GitHub token", "error", err)
+				fmt.Printf("❌ Error loading GitHub token: %v\n", err)
+			}
+		} else if githubToken != "" {
+			prefixLen := 10
+			if len(githubToken) < prefixLen {
+				prefixLen = len(githubToken)
+			}
+			logging.Debug("Found GitHub token in config", "token_length", len(githubToken), "token_prefix", githubToken[:prefixLen])
+			fmt.Printf("✅ Found GitHub token in config\n")
+		} else {
+			logging.Debug("GitHub token not found in config")
+			fmt.Printf("ℹ️ No GitHub token found in config\n")
+			useDeviceFlow = true
+		}
+		
+		// Step 3: If no token, trigger login flow
+		nonInteractiveFlag := viper.GetBool("non_interactive")
+		cliNonInteractive := viper.GetString("prompt") != ""
+		
+		if useDeviceFlow && !nonInteractiveFlag && !cliNonInteractive {
+			logging.Info("Starting GitHub Copilot authentication flow")
+			fmt.Printf("🔑 Starting GitHub Copilot authentication flow\n")
+			
+			// Create temporary client for auth flow
+			tempClient := &copilotClient{
 				providerOptions: opts,
 				options:         copilotOpts,
 				httpClient:      httpClient,
 			}
+			
+			// Use device code flow to get token
+			var err error
+			githubToken, err = tempClient.performDeviceCodeFlow()
+			if err != nil {
+				logging.Error("Device code authentication failed", "error", err)
+				fmt.Printf("❌ Authentication failed: %v\n", err)
+				
+				// Return dummy client so app doesn't crash
+				return createDummyClient(opts, copilotOpts, httpClient)
+			}
+		} else if useDeviceFlow {
+			// Can't do auth flow in non-interactive mode
+			logging.Error("Authentication required but running in non-interactive mode")
+			fmt.Printf("❌ Authentication required but running in non-interactive mode\n")
+			fmt.Printf("⚠️ Run OpenCode in interactive mode first to authenticate with Copilot\n")
+			
+			// Return dummy client
+			return createDummyClient(opts, copilotOpts, httpClient)
+		}
+		
+		// If we have a GitHub token but no bearer token, exchange for bearer token
+		if githubToken != "" {
+			// Create temporary client for token exchange
+			tempClient := &copilotClient{
+				providerOptions: opts,
+				options:         copilotOpts,
+				httpClient:      httpClient,
+			}
+			
+			// Exchange GitHub token for bearer token
+			var err error
+			logging.Debug("Exchanging GitHub token for Copilot bearer token")
+			fmt.Printf("🔄 Exchanging GitHub token for Copilot bearer token...\n")
+			
+			bearerToken, err = tempClient.exchangeGitHubToken(githubToken)
+			if err != nil {
+				logging.Error("Failed to exchange GitHub token", "error", err)
+				fmt.Printf("❌ Failed to exchange GitHub token: %v\n", err)
+				
+				// Return dummy client
+				return createDummyClient(opts, copilotOpts, httpClient)
+			}
+		} else {
+			// No GitHub token and can't trigger auth flow
+			logging.Error("No GitHub token available and cannot trigger authentication")
+			fmt.Printf("❌ No GitHub token available and cannot trigger authentication\n")
+			
+			// Return dummy client
+			return createDummyClient(opts, copilotOpts, httpClient)
 		}
 	}
 
 	copilotOpts.bearerToken = bearerToken
 
+	// Step 4: With token ready, create client and proceed with normal operation
+	return createCopilotClient(opts, copilotOpts, httpClient, bearerToken)
+}
+
+// createDummyClient creates a placeholder client when authentication fails
+func createDummyClient(opts providerClientOptions, options copilotOptions, httpClient *http.Client) *copilotClient {
+	logging.Debug("Creating dummy Copilot client due to authentication issues")
+	fmt.Printf("ℹ️ Creating temporary client due to authentication issues\n")
+	
+	dummyClient := openai.NewClient(
+		option.WithBaseURL("https://api.githubcopilot.com"),
+		option.WithAPIKey("dummy-for-initialization"),
+	)
+	
+	return &copilotClient{
+		providerOptions: opts,
+		options:         options,
+		client:          dummyClient,
+		httpClient:      httpClient,
+	}
+}
+
+// createCopilotClient creates a fully configured client for GitHub Copilot
+func createCopilotClient(opts providerClientOptions, options copilotOptions, httpClient *http.Client, bearerToken string) *copilotClient {
 	// GitHub Copilot API base URL
 	baseURL := "https://api.githubcopilot.com"
+	customURL := viper.GetString("providers.copilot.baseUrl")
+	if customURL != "" {
+		logging.Debug("Using custom baseUrl for Copilot from config", "baseUrl", customURL)
+		fmt.Printf("🌐 Using custom baseUrl for Copilot: %s\n", customURL)
+		baseURL = customURL
+	}
+	
+	// Make sure baseURL is set
+	if baseURL == "" {
+		logging.Error("Missing baseURL for Copilot client")
+		fmt.Printf("❌ Missing baseURL for Copilot client\n")
+		return createDummyClient(opts, options, httpClient)
+	}
+	
+	// If no bearer token, return dummy client
+	if bearerToken == "" {
+		logging.Error("No bearer token available for Copilot client")
+		return createDummyClient(opts, options, httpClient)
+	}
 
+	// Create the proper client with all required options and headers
+	prefixLen := 10
+	if len(bearerToken) < prefixLen {
+		prefixLen = len(bearerToken)
+	}
+	logging.Debug("Creating Copilot client with valid bearer token", 
+		"baseURL", baseURL, 
+		"model", opts.model.APIModel, 
+		"token_length", len(bearerToken),
+		"bearerToken_prefix", bearerToken[:prefixLen])
+	fmt.Printf("✅ Creating Copilot client with valid bearer token\n")
+	
+	// Create OpenAI client with all required settings for Copilot
 	openaiClientOptions := []option.RequestOption{
 		option.WithBaseURL(baseURL),
 		option.WithAPIKey(bearerToken), // Use bearer token as API key
+		option.WithHeader("User-Agent", "GithubCopilot/1.133.0"),
+		option.WithHeader("Editor-Version", "vscode/1.78.0"),
+		option.WithHeader("Editor-Plugin-Version", "copilot-chat/0.8.0"),
+		option.WithHeader("Accept", "application/json"),
+		option.WithHeader("X-GitHub-Api-Version", "2022-11-28"), // Required GitHub API version
 	}
 
-	// Add GitHub Copilot specific headers
-	openaiClientOptions = append(openaiClientOptions,
-		option.WithHeader("Editor-Version", "OpenCode/1.0"),
-		option.WithHeader("Editor-Plugin-Version", "OpenCode/1.0"),
-		option.WithHeader("Copilot-Integration-Id", "vscode-chat"),
-	)
-
-	// Add any extra headers
-	if copilotOpts.extraHeaders != nil {
-		for key, value := range copilotOpts.extraHeaders {
+	// Add any extra headers from options
+	if options.extraHeaders != nil {
+		for key, value := range options.extraHeaders {
 			openaiClientOptions = append(openaiClientOptions, option.WithHeader(key, value))
 		}
 	}
 
+	// Create client with proper headers
 	client := openai.NewClient(openaiClientOptions...)
-	// logging.Debug("Copilot client created", "opts", opts, "copilotOpts", copilotOpts, "model", opts.model)
+	fmt.Printf("✅ GitHub Copilot client created successfully\n")
+	fmt.Printf("✅ Using model: %s (%s)\n", opts.model.Name, opts.model.APIModel)
+	
+	// Create and return the copilotClient
 	return &copilotClient{
 		providerOptions: opts,
-		options:         copilotOpts,
+		options: copilotOptions{
+			reasoningEffort: options.reasoningEffort,
+			extraHeaders: options.extraHeaders,
+			bearerToken: bearerToken,
+		},
 		client:          client,
 		httpClient:      httpClient,
 	}
@@ -281,8 +845,30 @@ func (c *copilotClient) finishReason(reason string) message.FinishReason {
 }
 
 func (c *copilotClient) preparedParams(messages []openai.ChatCompletionMessageParamUnion, tools []openai.ChatCompletionToolParam) openai.ChatCompletionNewParams {
+	logging.Debug("Copilot preparedParams start", "modelID", c.providerOptions.model.ID, "apiModel", c.providerOptions.model.APIModel)
+	
+	// For Claude models, use the proper model name format
+	apiModel := c.providerOptions.model.APIModel
+	if c.isAnthropicModel() {
+		logging.Debug("Using Claude model", "original_api_model", apiModel)
+		fmt.Printf("📢 Using Claude model: %s through GitHub Copilot\n", apiModel)
+		// The Claude models might need a special format for Copilot
+		if strings.HasPrefix(apiModel, "claude-") {
+			logging.Debug("Using Claude model with standard format", "api_model", apiModel)
+			fmt.Printf("📢 Claude model name format: %s\n", apiModel)
+		}
+	} else {
+		fmt.Printf("📢 Using non-Claude model: %s through GitHub Copilot\n", apiModel)
+	}
+	
+	// Log important model details
+	logging.Debug("Model details", 
+		"name", c.providerOptions.model.Name,
+		"context_window", c.providerOptions.model.ContextWindow,
+		"max_tokens", c.providerOptions.maxTokens)
+	
 	params := openai.ChatCompletionNewParams{
-		Model:    openai.ChatModel(c.providerOptions.model.APIModel),
+		Model:    openai.ChatModel(apiModel),
 		Messages: messages,
 		Tools:    tools,
 	}
@@ -303,6 +889,10 @@ func (c *copilotClient) preparedParams(messages []openai.ChatCompletionMessagePa
 		params.MaxTokens = openai.Int(c.providerOptions.maxTokens)
 	}
 
+	jsonData, err := json.Marshal(params)
+	if err == nil {
+		logging.Debug("Copilot request parameters", "params", string(jsonData))
+	}
 	return params
 }
 
@@ -311,36 +901,81 @@ func (c *copilotClient) send(ctx context.Context, messages []message.Message, to
 	cfg := config.Get()
 	var sessionId string
 	requestSeqId := (len(messages) + 1) / 2
+	
+	// Always log parameters in debug mode
+	jsonData, _ := json.Marshal(params)
+	logging.Debug("Copilot API request parameters", "model", params.Model, "messages_count", len(params.Messages), "tools_count", len(params.Tools))
+	logging.Debug("Copilot API full request", "params", string(jsonData))
+	logging.Debug("Model being used for request", "model_id", c.providerOptions.model.ID, "api_model", c.providerOptions.model.APIModel)
+	
 	if cfg.Debug {
-		// jsonData, _ := json.Marshal(params)
-		// logging.Debug("Prepared messages", "messages", string(jsonData))
 		if sid, ok := ctx.Value(toolsPkg.SessionIDContextKey).(string); ok {
 			sessionId = sid
 		}
-		jsonData, _ := json.Marshal(params)
 		if sessionId != "" {
 			filepath := logging.WriteRequestMessageJson(sessionId, requestSeqId, params)
 			logging.Debug("Prepared messages", "filepath", filepath)
-		} else {
-			logging.Debug("Prepared messages", "messages", string(jsonData))
 		}
 	}
 
 	attempts := 0
 	for {
 		attempts++
+		fmt.Printf("🔄 Sending request to GitHub Copilot API...\n")
+		logging.Debug("About to send Copilot API request", "model", string(params.Model), "max_tokens_param", params.MaxTokens, "max_completion_tokens_param", params.MaxCompletionTokens, "tools_count", len(tools))
+		logging.Debug("Sending request to Copilot API", "baseURL", "https://api.githubcopilot.com", "model", params.Model)
+		
+		// Dump headers for debugging
+		logging.Debug("Request is being made with OpenAI client", "client_type", fmt.Sprintf("%T", c.client))
+		fmt.Printf("📋 Making request with client: %T\n", c.client)
+		
+		// Dump important request parameters
+		fmt.Printf("📋 Request model: %s\n", params.Model)
+		fmt.Printf("📋 Request max tokens: %d\n", c.providerOptions.maxTokens)
+		
+		// Make the API request
 		copilotResponse, err := c.client.Chat.Completions.New(
 			ctx,
 			params,
 		)
+		logging.Debug("Received response from Copilot API", "error", err != nil)
 
 		// If there is an error we are going to see if we can retry the call
 		if err != nil {
+			fmt.Printf("❌ Copilot API request failed: %v\n", err)
+			logging.Error("Copilot API request failed", "error", err)
+			var apierr *openai.Error
+			if errors.As(err, &apierr) {
+				fmt.Printf("❌ API Error: Status %d, Type %s\n", apierr.StatusCode, apierr.Type)
+				fmt.Printf("❌ Error Response: %s\n", apierr.RawJSON())
+				logging.Error("Copilot API error details", "status", apierr.StatusCode, "type", apierr.Type, "raw_json", apierr.RawJSON())
+				
+				// Check if this is a model not found error
+				if apierr.StatusCode == 400 {
+					if strings.Contains(string(apierr.RawJSON()), "model") {
+						fmt.Printf("⚠️ This might be because the model '%s' is not available or not supported by GitHub Copilot.\n", params.Model)
+						fmt.Printf("⚠️ Automatically trying 'copilot.gpt-4o' instead...\n")
+						
+						// If this was a Claude model, try with GPT-4o as fallback
+						if c.isAnthropicModel() && attempts < 2 {
+							logging.Info("Trying with GPT-4o model instead of Claude")
+							params.Model = "gpt-4o"
+							continue
+						} else {
+							fmt.Printf("⚠️ Try manually changing your config to use 'copilot.gpt-4o' instead.\n")
+						}
+					}
+				}
+			}
+			
 			retry, after, retryErr := c.shouldRetry(attempts, err)
 			if retryErr != nil {
+				fmt.Printf("❌ Cannot retry: %v\n", retryErr)
+				logging.Error("Retry error", "error", retryErr)
 				return nil, retryErr
 			}
 			if retry {
+				fmt.Printf("⏳ Retrying in %d ms (attempt %d of %d)...\n", after, attempts, maxRetries)
 				logging.WarnPersist(fmt.Sprintf("Retrying due to rate limit... attempt %d of %d", attempts, maxRetries), logging.PersistTimeArg, time.Millisecond*time.Duration(after+100))
 				select {
 				case <-ctx.Done():
@@ -350,6 +985,8 @@ func (c *copilotClient) send(ctx context.Context, messages []message.Message, to
 				}
 			}
 			return nil, retryErr
+		} else {
+			fmt.Printf("✅ Successful response from GitHub Copilot API!\n")
 		}
 
 		content := ""
@@ -579,6 +1216,17 @@ func (c *copilotClient) shouldRetry(attempts int, err error) (bool, int64, error
 				// Note: This is a simplified approach. In a production system,
 				// you might want to recreate the entire client with the new token
 				logging.Info("Refreshed Copilot bearer token")
+				
+				// Recreate the entire client with the new token
+				baseURL := "https://api.githubcopilot.com"
+				c.client = openai.NewClient(
+					option.WithBaseURL(baseURL),
+					option.WithAPIKey(newBearerToken),
+					option.WithHeader("Editor-Version", "OpenCode/1.0"),
+					option.WithHeader("Editor-Plugin-Version", "OpenCode/1.0"),
+					option.WithHeader("Copilot-Integration-Id", "vscode-chat"),
+				)
+				
 				return true, 1000, nil // Retry immediately with new token
 			}
 			logging.Error("Failed to refresh Copilot bearer token", "error", tokenErr)
@@ -587,7 +1235,14 @@ func (c *copilotClient) shouldRetry(attempts int, err error) (bool, int64, error
 	}
 	logging.Debug("Copilot API Error", "status", apierr.StatusCode, "headers", apierr.Response.Header, "body", apierr.RawJSON())
 
-	if apierr.StatusCode != 429 && apierr.StatusCode != 500 {
+	if apierr.StatusCode == 400 {
+		// Special handling for 400 Bad Request
+		logging.Error("Copilot API 400 Bad Request error", "error", err.Error(), "response_body", apierr.RawJSON())
+		
+		// Try to extract more details from the error
+		detailedErr := fmt.Errorf("Copilot API 400 Bad Request: %s", apierr.Error())
+		return false, 0, detailedErr
+	} else if apierr.StatusCode != 429 && apierr.StatusCode != 500 {
 		return false, 0, err
 	}
 
@@ -668,4 +1323,3 @@ func WithCopilotBearerToken(bearerToken string) CopilotOption {
 		options.bearerToken = bearerToken
 	}
 }
-


### PR DESCRIPTION
## Summary
This PR fixes the GitHub Copilot authentication flow in OpenCode, which currently has issues with token retrieval and exchange.

## Problem Description
Currently, the GitHub Copilot integration has several issues:

1. The code tries to use standard GitHub tokens (like those from `gh auth token`) which don't work with Copilot API because they lack the required Copilot scope
2. There's no proper authentication flow when no token is found
3. The token exchange process fails due to missing required headers and incorrect API version
4. Missing documentation on how to properly set up and use the Copilot integration

## Solution
This PR implements a complete authentication flow inspired by the one used in the Neovim Copilot plugin:

1. Properly checks for Copilot tokens in standard locations (hosts.json and apps.json)
2. Implements OAuth device code flow when no token is found
3. Adds proper GitHub API headers including the correct API version (X-GitHub-Api-Version: 2022-11-28)
4. Uses the standard Copilot client ID (same as used by VS Code and Neovim plugins)
5. Stores tokens in the standard location for reuse across sessions

## Documentation
Added comprehensive documentation to the README explaining:
- How to configure Copilot in OpenCode
- The authentication flow process
- Where tokens are stored

This PR makes Copilot integration work seamlessly with OpenCode, especially important for users wanting to access Claude models through Copilot.