### PR TITLE
Add config option to disable AI attributions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,18 +82,19 @@ type ShellConfig struct {
 
 // Config is the main configuration structure for the application.
 type Config struct {
-	Data         Data                              `json:"data"`
-	WorkingDir   string                            `json:"wd,omitempty"`
-	MCPServers   map[string]MCPServer              `json:"mcpServers,omitempty"`
-	Providers    map[models.ModelProvider]Provider `json:"providers,omitempty"`
-	LSP          map[string]LSPConfig              `json:"lsp,omitempty"`
-	Agents       map[AgentName]Agent               `json:"agents,omitempty"`
-	Debug        bool                              `json:"debug,omitempty"`
-	DebugLSP     bool                              `json:"debugLSP,omitempty"`
-	ContextPaths []string                          `json:"contextPaths,omitempty"`
-	TUI          TUIConfig                         `json:"tui"`
-	Shell        ShellConfig                       `json:"shell,omitempty"`
-	AutoCompact  bool                              `json:"autoCompact,omitempty"`
+	Data                 Data                              `json:"data"`
+	WorkingDir           string                            `json:"wd,omitempty"`
+	MCPServers           map[string]MCPServer              `json:"mcpServers,omitempty"`
+	Providers            map[models.ModelProvider]Provider `json:"providers,omitempty"`
+	LSP                  map[string]LSPConfig              `json:"lsp,omitempty"`
+	Agents               map[AgentName]Agent               `json:"agents,omitempty"`
+	Debug                bool                              `json:"debug,omitempty"`
+	DebugLSP             bool                              `json:"debugLSP,omitempty"`
+	ContextPaths         []string                          `json:"contextPaths,omitempty"`
+	TUI                  TUIConfig                         `json:"tui"`
+	Shell                ShellConfig                       `json:"shell,omitempty"`
+	AutoCompact          bool                              `json:"autoCompact,omitempty"`
+	DisableAIAttribution bool                              `json:"disableAIAttribution,omitempty"`
 }
 
 // Application constants
@@ -232,6 +233,7 @@ func setDefaults(debug bool) {
 	viper.SetDefault("contextPaths", defaultContextPaths)
 	viper.SetDefault("tui.theme", "opencode")
 	viper.SetDefault("autoCompact", true)
+	viper.SetDefault("disableAIAttribution", false)
 
 	// Set default shell from environment or fallback to /bin/bash
 	shellPath := os.Getenv("SHELL")


### PR DESCRIPTION
## Summary

Add a configuration option to disable AI attributions in commit messages and PR descriptions, providing users with control similar to Claude Code's attribution settings.

## Changes

- **Config Structure**: Added DisableAIAttribution boolean field to Config struct with proper JSON tag
- **Default Behavior**: Set default to false to maintain backward compatibility
- **Dynamic Attribution**: Updated bashDescription() function to conditionally include attribution strings based on config
- **Attribution Control**: When enabled, removes both commit and PR attribution strings

## Usage

Users can disable AI attributions by adding this to their .opencode.json config file:

```json
{
  "disableAIAttribution": true
}
```

## What Gets Disabled

When disableAIAttribution is set to true, the following are removed:
- 🤖 Generated with opencode from commit messages and PR descriptions  
- Co-Authored-By: opencode <noreply@opencode.ai> from commit messages